### PR TITLE
Fixed fxaa shaders to initialize integers

### DIFF
--- a/shaders/fxaa_f.glsl
+++ b/shaders/fxaa_f.glsl
@@ -1,10 +1,11 @@
+//GLSL
 #version 120
 #extension GL_EXT_gpu_shader4 : enable
 
 uniform sampler2D tex0; // 0
 uniform float vx_offset;
-uniform float rt_w; // GeeXLab built-in
-uniform float rt_h; // GeeXLab built-in
+uniform int rt_w; // GeeXLab built-in
+uniform int rt_h; // GeeXLab built-in
 uniform float FXAA_SPAN_MAX = 8.0;
 uniform float FXAA_REDUCE_MUL = 1.0/8.0;
 uniform float FXAA_SUBPIX_SHIFT = 1.0/4.0;

--- a/shaders/fxaa_v.glsl
+++ b/shaders/fxaa_v.glsl
@@ -1,8 +1,9 @@
+//GLSL
 #version 120
 varying vec4 posPos;
 uniform float FXAA_SUBPIX_SHIFT = 1.0/4.0;
-uniform float rt_w;
-uniform float rt_h;
+uniform int rt_w;
+uniform int rt_h;
 void main()
     {
     gl_Position = ftransform();

--- a/shaders/fxaadof_f.glsl
+++ b/shaders/fxaadof_f.glsl
@@ -1,11 +1,12 @@
+//GLSL
 #version 120
 #extension GL_EXT_gpu_shader4 : enable
 
 uniform sampler2D tex0; // 0
 uniform sampler2D fog; // fog-factor in R 
 uniform float vx_offset;
-uniform float rt_w; // GeeXLab built-in
-uniform float rt_h; // GeeXLab built-in
+uniform int rt_w; // GeeXLab built-in
+uniform int rt_h; // GeeXLab built-in
 uniform float FXAA_SPAN_MAX = 8.0;
 uniform float FXAA_REDUCE_MUL = 1.0/8.0;
 uniform float FXAA_SUBPIX_SHIFT = 1.0/4.0;


### PR DESCRIPTION
Hi,
since base.win.getProperties().getXSize() (in fxaa.py) returns integers, the shaders need to initialize integers , at least for it to work with my nvidia card.
